### PR TITLE
[ADDED] Functionality to show syntax highlighting passed to fragment.

### DIFF
--- a/example/src/main/java/dev/hossain/yaash/example/MainActivity.kt
+++ b/example/src/main/java/dev/hossain/yaash/example/MainActivity.kt
@@ -1,11 +1,55 @@
 package dev.hossain.yaash.example
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import dev.hossain.yaash.prismjs.ShowSourceCodeFragment
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        loadSourceCodeFragment()
     }
+
+    private fun loadSourceCodeFragment() {
+        val fragment = ShowSourceCodeFragment.newInstance(
+            formattedSourceCode = sourceCode,
+            language = "kotlin",
+            showLineNumbers = true
+        )
+
+        val fragmentManager = supportFragmentManager
+        val fragmentTransaction = fragmentManager.beginTransaction()
+        fragmentTransaction.add(R.id.fragment_container, fragment)
+        fragmentTransaction.commit()
+    }
+
+    // Sample code for syntax-highlight preview
+    private val sourceCode = """
+    |@SuppressLint("SetJavaScriptEnabled")
+    |override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    |    super.onViewCreated(view, savedInstanceState)
+    |    val webView: WebView = view.findViewById(R.id.web_view)
+    |
+    |    // https://stackoverflow.com/questions/57449900/letting-webview-on-android-work-with-prefers-color-scheme-dark?rq=1
+    |    if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+    |        WebSettingsCompat.setForceDark(webView.settings, WebSettingsCompat.FORCE_DARK_ON)
+    |    }
+    |
+    |    webView.apply {
+    |        settings.javaScriptEnabled = true
+    |        webChromeClient = WebViewChromeClient()
+    |        webViewClient = AppWebViewClient()
+    |
+    |        loadDataWithBaseURL(
+    |            ANDROID_ASSETS_PATH /* baseUrl */,
+    |            prismJsHtmlContent(sourceCode, language, showLineNumbers) /* html-data */,
+    |            "text/html" /* mimeType */,
+    |            "utf-8" /* encoding */,
+    |            "" /* failUrl */
+    |        )
+    |    }
+    |}
+    """.trimMargin()
 }

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -6,9 +6,8 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <fragment
-        android:id="@+id/fragment"
-        android:name="dev.hossain.yaash.prismjs.ShowSourceCodeFragment"
+    <FrameLayout
+        android:id="@+id/fragment_container"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/highlighter/src/main/assets/www/main.css
+++ b/highlighter/src/main/assets/www/main.css
@@ -2,12 +2,11 @@ body {
   font-family: 'Roboto', Arial, Helvetica, sans-serif;
 }
 
-code {
-    padding: .2em .4em;
+/* Some basic reset remove any default margin */
+html, body, div, span, pre, code {
     margin: 0;
-    font-size: 115%;
-    background-color: #dcdcdc;
-    border-radius: 6px;
+	padding: 0;
+	border: 0;
 }
 
 /**

--- a/highlighter/src/main/java/dev/hossain/yaash/prismjs/PrismJsHtmlTemplate.kt
+++ b/highlighter/src/main/java/dev/hossain/yaash/prismjs/PrismJsHtmlTemplate.kt
@@ -1,0 +1,37 @@
+package dev.hossain.yaash.prismjs
+
+/**
+ * This is an example how template can be defined with variables.
+ *
+ * You may need to add more variables to have more customizations through additional plugins.
+ * For example:
+ * - Highlight line numbers
+ * - Show invisible characters
+ * - and so on
+ * @see <a href="https://prismjs.com/download.html">Prism JS Download</a> options for more information.
+ */
+fun prismJsHtmlContent(
+    formattedSourceCode: String,
+    language: String,
+    showLineNumbers: Boolean = true
+): String {
+    return """<!DOCTYPE html>
+<html>
+<head>
+    <!-- https://developer.chrome.com/multidevice/webview/pixelperfect -->
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="www/main.css" rel="stylesheet"/>
+
+    <!-- https://prismjs.com/ -->
+    <link href="www/prism.css" rel="stylesheet"/>
+    <script src="www/prism.js"></script>
+    <!-- HTML/XML encode entities: https://mothereff.in/html-entities -->
+</head>
+<body>
+<pre class="${if (showLineNumbers) "line-numbers" else ""}">
+<code class="language-${language}">${formattedSourceCode}</code>
+</pre>
+</body>
+</html>
+"""
+}

--- a/highlighter/src/main/java/dev/hossain/yaash/prismjs/ShowSourceCodeFragment.kt
+++ b/highlighter/src/main/java/dev/hossain/yaash/prismjs/ShowSourceCodeFragment.kt
@@ -10,25 +10,58 @@ import androidx.fragment.app.Fragment
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
 import dev.hossain.yaash.R
+import dev.hossain.yaash.prismjs.ShowSourceCodeFragment.Companion.newInstance
 import dev.hossain.yaash.webclient.AppWebViewClient
 import dev.hossain.yaash.webclient.WebViewChromeClient
 
+/**
+ * Fragment that shows syntax highlighted source code.
+ * Use [newInstance] to provide source code and other configuration parameters.
+ */
 class ShowSourceCodeFragment : Fragment() {
     companion object {
         private const val ANDROID_ASSETS_PATH = "file:///android_asset/"
+
+        private const val ARG_KEY_SOURCE_CODE_CONTENT = "ARG_SOURCE_CODE"
+        private const val ARG_KEY_CODE_LANGUAGE = "ARG_SOURCE_CODE_LANGUAGE_NAME"
+        private const val ARG_KEY_SHOW_LINE_NUMBERS = "ARG_SHOW_LINE_NUMBER"
+
+        /**
+         * Creates new instance of the fragment with required values to render the syntax highlighted code.
+         */
+        fun newInstance(
+            formattedSourceCode: String,
+            language: String,
+            showLineNumbers: Boolean = false
+        ) = ShowSourceCodeFragment().apply {
+            arguments = Bundle(4).apply {
+                putString(ARG_KEY_SOURCE_CODE_CONTENT, formattedSourceCode)
+                putString(ARG_KEY_CODE_LANGUAGE, language)
+                putBoolean(ARG_KEY_SHOW_LINE_NUMBERS, showLineNumbers)
+            }
+        }
     }
 
-    private lateinit var webView: WebView
+    private val sourceCode: String by lazy {
+        arguments?.getString(ARG_KEY_SOURCE_CODE_CONTENT)
+            ?: throw IllegalArgumentException("Use `newInstance()` to provide required data")
+    }
+    private val language: String by lazy {
+        arguments?.getString(ARG_KEY_CODE_LANGUAGE)
+            ?: throw IllegalArgumentException("Use `newInstance()` to provide required data")
+    }
+    private val showLineNumbers: Boolean by lazy {
+        arguments?.getBoolean(ARG_KEY_SHOW_LINE_NUMBERS, false) ?: false
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val rootView = inflater.inflate(R.layout.fragment_highlighter, container, false)
-        webView = rootView.findViewById(R.id.web_view)
-        return rootView
+        return inflater.inflate(R.layout.fragment_highlighter, container, false)
     }
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val webView: WebView = view.findViewById(R.id.web_view)
 
         // https://stackoverflow.com/questions/57449900/letting-webview-on-android-work-with-prefers-color-scheme-dark?rq=1
         if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
@@ -39,7 +72,14 @@ class ShowSourceCodeFragment : Fragment() {
             settings.javaScriptEnabled = true
             webChromeClient = WebViewChromeClient()
             webViewClient = AppWebViewClient()
-            loadUrl("${ANDROID_ASSETS_PATH}_template.html")
+
+            loadDataWithBaseURL(
+                ANDROID_ASSETS_PATH /* baseUrl */,
+                prismJsHtmlContent(sourceCode, language, showLineNumbers) /* html-data */,
+                "text/html" /* mimeType */,
+                "utf-8" /* encoding */,
+                "" /* failUrl */
+            )
         }
     }
 }

--- a/highlighter/src/main/java/dev/hossain/yaash/prismjs/ShowStaticSourceCodeFragment.kt
+++ b/highlighter/src/main/java/dev/hossain/yaash/prismjs/ShowStaticSourceCodeFragment.kt
@@ -1,0 +1,50 @@
+package dev.hossain.yaash.prismjs
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
+import androidx.fragment.app.Fragment
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
+import dev.hossain.yaash.R
+import dev.hossain.yaash.webclient.AppWebViewClient
+import dev.hossain.yaash.webclient.WebViewChromeClient
+
+/**
+ * Fragment that loads hard coded static HTML file with syntax highlighting.
+ *
+ * @see ShowSourceCodeFragment
+ */
+class ShowStaticSourceCodeFragment : Fragment() {
+    companion object {
+        private const val ANDROID_ASSETS_PATH = "file:///android_asset/"
+    }
+
+    private lateinit var webView: WebView
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val rootView = inflater.inflate(R.layout.fragment_highlighter, container, false)
+        webView = rootView.findViewById(R.id.web_view)
+        return rootView
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // https://stackoverflow.com/questions/57449900/letting-webview-on-android-work-with-prefers-color-scheme-dark?rq=1
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+            WebSettingsCompat.setForceDark(webView.settings, WebSettingsCompat.FORCE_DARK_ON)
+        }
+
+        webView.apply {
+            settings.javaScriptEnabled = true
+            webChromeClient = WebViewChromeClient()
+            webViewClient = AppWebViewClient()
+            loadUrl("${ANDROID_ASSETS_PATH}_template.html")
+        }
+    }
+}


### PR DESCRIPTION
Use `newInstance()` to provide data which is loaded via `prismJsHtmlContent()` template